### PR TITLE
fix: normalize publisher ID to lowercase

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "codevisualizer",
   "displayName": "CodeVisualizer",
-  "version": "1.0.3",
-  "publisher": "DucPhamNgoc",
+  "version": "1.0.5",
+  "publisher": "ducphamngoc",
   "description": "Real-time interactive flowcharts for your code with AI-powered insights",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Change publisher from 'DucPhamNgoc' to 'ducphamngoc'
- Fixes manifest fetch errors on VS Code 1.105.1+
- Bump version to 1.0.5